### PR TITLE
Replaced URL with a faster mirror site.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN yum install -y java-1.8.0-openjdk java-1.8.0-openjdk-devel && \
 # Install Maven 3.5.2
 ARG MAVEN_VER
 ENV MAVEN_VERSION $MAVEN_VER
-RUN (curl -fSL https://www-eu.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | \
+RUN (curl -fSL http://apachemirror.wuchna.com/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | \
     tar -zx -C /usr/local) && \
     mv /usr/local/apache-maven-$MAVEN_VERSION /usr/local/maven && \
     ln -sf /usr/local/maven/bin/mvn /usr/local/bin/mvn && \


### PR DESCRIPTION
Refer https://maven.apache.org/download.cgi for more mirrors.